### PR TITLE
fix: do not throw for responses with empty lists

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -17,7 +17,6 @@ import * as assert from 'assert';
 import {GoogleAuth, JWT} from 'google-auth-library';
 import {clouddebugger_v2, google} from 'googleapis';
 import * as util from 'util';
-
 import * as types from './index';
 
 const cloudDebugger = google.clouddebugger('v2').debugger;
@@ -99,12 +98,9 @@ export class Wrapper {
       auth: this.auth,
     };
     const response = await cloudDebugger.debuggees.list(request);
-    if (!response.data.debuggees) {
-      throw new Error(
-          'The debuggees.list response from Stackdriver Debug is missing ' +
-          `the list of debuggees: ${util.inspect(response, {depth: null})}`);
-    }
-    if (this.isDebuggeeList(response.data.debuggees)) {
+    if (response.data.debuggees === undefined) {
+      return [];
+    } else if (this.isDebuggeeList(response.data.debuggees)) {
       return response.data.debuggees;
     } else {
       throw new Error(
@@ -166,14 +162,16 @@ export class Wrapper {
       auth: this.auth,
     };
     const response = await cloudDebugger.debuggees.breakpoints.list(request);
-    if (!response.data.nextWaitToken || !response.data.breakpoints) {
+    if (!response.data.nextWaitToken) {
       throw new Error(
           'The debuggees.breakpoints.list response from Stackdriver Debug ' +
-          'should have the breakpoints and nextWaitToken properties, but ' +
-          `it returned this: ${util.inspect(response.data, {depth: null})}`);
+          'should have the nextWaitToken property, but it returned this: ' +
+          util.inspect(response.data, {depth: null}));
     }
     this.waitToken = response.data.nextWaitToken;
-    if (this.isPendingBreakpointList(response.data.breakpoints)) {
+    if (response.data.breakpoints === undefined) {
+      return [];
+    } else if (this.isPendingBreakpointList(response.data.breakpoints)) {
       return response.data.breakpoints;
     } else {
       throw new Error(

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --require hard-rejection/register
 --require source-map-support/register
 --timeout 10000
+--throw-deprecation

--- a/test/test-wrapper.ts
+++ b/test/test-wrapper.ts
@@ -235,8 +235,10 @@ describe('wrapper.ts', () => {
             .get(API_URL + '/debuggees')
             .query(true)
             .reply(200, response);
-        await assertRejects(
-            wrapper.debuggeesList(), /TypeError: debuggeeList is not iterable/);
+        // Node 6: Cannot read property 'Symbol(Symbol.iterator)' of null
+        // Node 6: debuggeeList[Symbol.iterator] is not a function
+        // Node 8+: TypeError: debuggeeList is not iterable
+        await assertRejects(wrapper.debuggeesList(), /TypeError:/);
       });
     });
 


### PR DESCRIPTION
Responses that return lists, such as `debuggees.list` and `debuggees.breakpoints.list`, set the list property to `undefined` when it is empty. This commit deals with it.