### PR TITLE
 Allow for more customized authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,14 +123,16 @@ export interface DebugProxyInterface extends EventEmitter {
    */
   getProjectId(): ProjectId;
   /**
-   * @param keyFilename - path to the GCP credentials key file
-   * corresponding to the project that is to be debugged
+   * Authorize the DebugProxy with GCP credentials and a GCP project ID.
+   *
+   * @param keyFilename Optional, path to the GCP credentials file. If unset
+   *    application default credentials will be used.
+   * @param projectId - Optional, the GCP project ID of the project to debug.
+   *    If unset the project ID from the key file will be used or from the local
+   *    environment (see https://github.com/google/google-auth-library-nodejs/)
+   *    if the key file does not contain a project ID.
    */
-  setProjectByKeyFile(keyFilename?: SourcePath): Promise<void>;
-
-  // TODO: setProjectById.
-  // https://github.com/GoogleCloudPlatform/cloud-debug-proxy-common/issues/14
-
+  authorize(keyFilename?: SourcePath, projectId?: string): Promise<void>;
   /**
    * @returns debugger ID for the selected GCP debuggee
    */
@@ -284,8 +286,8 @@ export class DebugProxy extends EventEmitter implements DebugProxyInterface {
     return this.wrapper.getProjectId();
   }
 
-  async setProjectByKeyFile(keyFilename?: SourcePath) {
-    await this.wrapper.authorize(keyFilename);
+  async authorize(keyFilename?: SourcePath, projectId?: string) {
+    await this.wrapper.authorize(keyFilename, projectId);
   }
 
   getDebuggerId(): DebuggerId {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -68,15 +68,17 @@ export class Wrapper {
     return true;
   }
 
-  async authorize(keyFilename?: types.SourcePath) {
+  async authorize(keyFilename?: types.SourcePath, projectId?: string) {
     const credential = await this.googleAuth.getClient({
       keyFilename,
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     });
-    if (!credential.projectId) {
-      throw new Error('The given keyFile must contain the project ID.');
+
+    this.projectId = projectId || credential.projectId ||
+        await this.googleAuth.getProjectId();
+    if (!this.projectId) {
+      throw new Error('The project ID cannot be determined.');
     }
-    this.projectId = credential.projectId;
     this.auth = credential as JWT;
   }
 

--- a/test/fixtures/application_default_credentials_no_project.json
+++ b/test/fixtures/application_default_credentials_no_project.json
@@ -1,0 +1,4 @@
+{
+  "private_key": "private-key",
+  "client_email": "client-email"
+}


### PR DESCRIPTION
Allow the user to explicitly set the project ID they want to debug and also pick up the default project ID. This is especially useful when using application default credentials set by gcloud which may not have a project id associated with them.

Fixes #14 