### PR TITLE
[DO NOT SUBMIT] Enable all breakpoints to be shown, not just breakpoints set by the proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,6 @@ export class DebugProxy extends EventEmitter implements DebugProxyInterface {
 
   async updatePendingBreakpoints(
       block: boolean, localOnly = false, includeAllUsers = false,
-      includeInactive = true,
       cancellationToken: CancellationToken = new CancellationToken()) {
     this.localOnly = localOnly;
     /* debuggees.breakpoints.list times out until the breakpoint list changes.
@@ -196,7 +195,7 @@ export class DebugProxy extends EventEmitter implements DebugProxyInterface {
     while (!cancellationToken.isCancelled()) {
       try {
         this.breakpointList = await this.wrapper.debuggeesBreakpointsList(
-            block, includeAllUsers, includeInactive);
+            block, includeAllUsers);
         break;
       } catch (error) {
         if (!error.response || error.response.status !== ABORTED_ERROR_CODE) {
@@ -206,7 +205,7 @@ export class DebugProxy extends EventEmitter implements DebugProxyInterface {
     }
 
     if (this.localOnly) {
-      // check for changes only to local breakpoints before emitting.
+      // TODO: check for changes only to local breakpoints before emitting.
     } else {
       this.emit('updatedBreakpoints');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ export class DebugProxy extends EventEmitter implements DebugProxyInterface {
     }
 
     if (this.localOnly) {
-      // check for changes only to local breakpoints
+      // check for changes only to local breakpoints before emitting.
     } else {
       this.emit('updatedBreakpoints');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,11 @@ export class DebugProxy extends EventEmitter implements DebugProxyInterface {
       }
     }
 
-    this.emit('updatedBreakpoints');
+    if (this.localOnly) {
+      // check for changes only to local breakpoints
+    } else {
+      this.emit('updatedBreakpoints');
+    }
   }
 
   getProjectId(): ProjectId {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -148,8 +148,7 @@ export class Wrapper {
   }
 
   async debuggeesBreakpointsList(
-      wait: boolean, includeAllUsers: boolean,
-      includeInactive: boolean): Promise<types.Breakpoint[]> {
+      wait: boolean, includeAllUsers: boolean): Promise<types.Breakpoint[]> {
     if (!this.auth) {
       throw new Error('You must select a project before continuing.');
     }
@@ -160,8 +159,8 @@ export class Wrapper {
       debuggeeId: this.debuggeeId,
       waitToken: wait ? this.waitToken : '',
       auth: this.auth,
+      includeInactive: true,
       includeAllUsers,
-      includeInactive,
     };
     const response = await cloudDebugger.debuggees.breakpoints.list(request);
     if (!response.data.nextWaitToken) {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -147,7 +147,9 @@ export class Wrapper {
     return response.data.breakpoint;
   }
 
-  async debuggeesBreakpointsList(wait: boolean): Promise<types.Breakpoint[]> {
+  async debuggeesBreakpointsList(
+      wait: boolean, includeAllUsers: boolean,
+      includeInactive: boolean): Promise<types.Breakpoint[]> {
     if (!this.auth) {
       throw new Error('You must select a project before continuing.');
     }
@@ -158,6 +160,8 @@ export class Wrapper {
       debuggeeId: this.debuggeeId,
       waitToken: wait ? this.waitToken : '',
       auth: this.auth,
+      includeAllUsers,
+      includeInactive,
     };
     const response = await cloudDebugger.debuggees.breakpoints.list(request);
     if (!response.data.nextWaitToken) {


### PR DESCRIPTION
This is just a partial implementation for #19 as I wanted to see your opinions before I clean it up and write tests.

When I was looking through the implantation of the of DebugProxy I found it a little hard to work with as it was very focused on specific use cases and made assumptions about what consumers would want.  IMO I think it would be a little easier to start off with a more open model and as more users adopt it find common pain points that can we removed.

My general proposal is:
- rely on the breakpoint list from the Stackdriver Debugger API as the source of truth for breakpoints
- allow toggling of local vs non local breakpoints
- notify users of all changes to breakpoints (not just hits) as the Stackdriver Debugger API can return other useful information. 

Let me know what you think!