### PR TITLE
test: fail when given keyfile does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "typescript": "3.1.x"
   },
   "dependencies": {
-    "google-auth-library": "^1.6.1",
-    "googleapis": "^33.0.0",
+    "google-auth-library": "^2.0.0",
+    "googleapis": "^34.0.0",
     "p-limit": "^2.0.0"
   },
   "scripts": {

--- a/test/nocks.ts
+++ b/test/nocks.ts
@@ -27,3 +27,9 @@ export function oauth2(
         refresh_token: '1/test-refresh-token',
       });
 }
+
+export function notGCE() {
+  return nock('http://metadata.google.internal')
+      .get('/computeMetadata/v1/instance')
+      .replyWithError({code: 'ENOTFOUND'});
+}

--- a/test/test-wrapper.ts
+++ b/test/test-wrapper.ts
@@ -125,9 +125,10 @@ describe('wrapper.ts', () => {
 
       it('should fail if no credentials are given', async () => {
         const wrapper = new Wrapper();
+        nocks.notGCE();
         await assertRejects(
             wrapper.authorize(),
-            /application default credentials: Could not load the default/);
+            /Error: Could not load the default credentials\./);
       });
 
       it('should support Application Default Credentials', async () => {
@@ -139,9 +140,10 @@ describe('wrapper.ts', () => {
 
       it('should not cache the supported credentials', async () => {
         const wrapper = new Wrapper();
+        nocks.notGCE();
         await assertRejects(
             wrapper.authorize(),
-            /application default credentials: Could not load the default/);
+            /Error: Could not load the default credentials\./);
       });
 
       it('should support Application Default Credentials, pass pid',
@@ -185,8 +187,12 @@ describe('wrapper.ts', () => {
         process.env = {};
       });
 
-      // TODO: it should fail if file not found; wait until issue fixed
-      // https://github.com/google/google-auth-library-nodejs/issues/395
+      it('should fail if file not found', async () => {
+        const wrapper = new Wrapper();
+        await assertRejects(
+            wrapper.authorize('DOES_NOT_EXIST'),
+            /ENOENT: no such file or directory, open.*DOES_NOT_EXIST/);
+      });
 
       it('should support keyFile credentials', async () => {
         const wrapper = new Wrapper();


### PR DESCRIPTION
This pull request relies on the newly updated google-auth-library and googleapis, so #26 and #28 can be closed.